### PR TITLE
Feat/auth pin biometric

### DIFF
--- a/internal/handlers/pin_handler.go
+++ b/internal/handlers/pin_handler.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/codeZe-us/vestroll-backend/internal/models"
+	"github.com/codeZe-us/vestroll-backend/internal/services"
+	"github.com/gin-gonic/gin"
+)
+
+// PINHandler manages PIN setup and authentication endpoints
+type PINHandler struct {
+	service *services.PINService
+}
+
+func NewPINHandler(service *services.PINService) *PINHandler {
+	return &PINHandler{service: service}
+}
+
+// RegisterRoutes registers PIN endpoints under /auth
+func (h *PINHandler) RegisterRoutes(router *gin.RouterGroup) {
+	router.POST("/setup-pin", h.SetupPIN)
+	router.POST("/login-pin", h.LoginPIN)
+}
+
+// SetupPIN handles POST /api/auth/setup-pin
+func (h *PINHandler) SetupPIN(c *gin.Context) {
+	var req models.SetupPINRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "validation_error", Message: err.Error()})
+		return
+	}
+	if err := h.service.SetupPIN(c.Request.Context(), req); err != nil {
+		status := http.StatusBadRequest
+		code := "validation_error"
+		// Adjust status codes for known error types
+		if strings.Contains(err.Error(), "internal") {
+			status = http.StatusInternalServerError
+			code = "internal_error"
+		}
+		c.JSON(status, models.ErrorResponse{Error: code, Message: err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, models.SetupPINResponse{Success: true, Message: "PIN setup successful"})
+}
+
+// LoginPIN handles POST /api/auth/login-pin
+func (h *PINHandler) LoginPIN(c *gin.Context) {
+	var req models.LoginPINRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{Error: "validation_error", Message: err.Error()})
+		return
+	}
+	if err := h.service.LoginPIN(c.Request.Context(), req); err != nil {
+		status := http.StatusUnauthorized
+		code := "invalid_pin"
+		if err.Error() == "pin not set" {
+			status = http.StatusNotFound
+			code = "not_found"
+		} else if strings.HasPrefix(err.Error(), "user_") || strings.HasPrefix(err.Error(), "pin") || strings.HasPrefix(err.Error(), "invalid pin") {
+			status = http.StatusBadRequest
+			code = "validation_error"
+		} else if strings.Contains(err.Error(), "internal") {
+			status = http.StatusInternalServerError
+			code = "internal_error"
+		}
+		c.JSON(status, models.ErrorResponse{Error: code, Message: err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, models.LoginPINResponse{Success: true, Message: "PIN authentication successful"})
+}

--- a/internal/repository/pin_repository.go
+++ b/internal/repository/pin_repository.go
@@ -1,0 +1,47 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/codeZe-us/vestroll-backend/internal/models"
+	"github.com/go-redis/redis/v8"
+)
+
+// PinRepository handles storage of user PINs in Redis
+type PinRepository struct {
+	client *redis.Client
+	ttl    time.Duration
+}
+
+func NewPinRepository(client *redis.Client, ttl time.Duration) *PinRepository {
+	return &PinRepository{client: client, ttl: ttl}
+}
+
+func (r *PinRepository) key(userID string) string {
+	return fmt.Sprintf("user_pin:%s", userID)
+}
+
+// Save stores the hashed PIN and salt for a user
+func (r *PinRepository) Save(ctx context.Context, userID string, data models.PinData) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return r.client.Set(ctx, r.key(userID), string(b), r.ttl).Err()
+}
+
+// Get retrieves the stored PIN data for a user
+func (r *PinRepository) Get(ctx context.Context, userID string) (models.PinData, error) {
+	val, err := r.client.Get(ctx, r.key(userID)).Result()
+	if err != nil {
+		return models.PinData{}, err
+	}
+	var data models.PinData
+	if err := json.Unmarshal([]byte(val), &data); err != nil {
+		return models.PinData{}, err
+	}
+	return data, nil
+}

--- a/internal/services/pin_service.go
+++ b/internal/services/pin_service.go
@@ -1,0 +1,85 @@
+package services
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"regexp"
+	"time"
+
+	"github.com/codeZe-us/vestroll-backend/internal/models"
+	"github.com/codeZe-us/vestroll-backend/internal/repository"
+)
+
+// PINService encapsulates PIN setup and authentication logic
+type PINService struct {
+	repo *repository.PinRepository
+}
+
+func NewPINService(repo *repository.PinRepository) *PINService {
+	return &PINService{repo: repo}
+}
+
+// ValidatePINFormat ensures PIN is 4-6 digits numeric
+func (s *PINService) ValidatePINFormat(pin string) error {
+	if len(pin) < 4 || len(pin) > 6 {
+		return errors.New("pin must be 4 to 6 digits")
+	}
+	matched, _ := regexp.MatchString("^[0-9]+$", pin)
+	if !matched {
+		return errors.New("pin must contain only digits")
+	}
+	return nil
+}
+
+func generateSalt(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func hashPIN(pin, salt string) string {
+	sum := sha256.Sum256([]byte(pin + ":" + salt))
+	return hex.EncodeToString(sum[:])
+}
+
+// SetupPIN validates and stores the user's PIN (salted+hashed)
+func (s *PINService) SetupPIN(ctx context.Context, req models.SetupPINRequest) error {
+	if req.UserID == "" {
+		return errors.New("user_id is required")
+	}
+	if err := s.ValidatePINFormat(req.PIN); err != nil {
+		return err
+	}
+	salt, err := generateSalt(16)
+	if err != nil {
+		return err
+	}
+	hash := hashPIN(req.PIN, salt)
+	data := models.PinData{Salt: salt, Hash: hash, CreatedAt: time.Now()}
+	return s.repo.Save(ctx, req.UserID, data)
+}
+
+// LoginPIN verifies the provided PIN against stored hash
+func (s *PINService) LoginPIN(ctx context.Context, req models.LoginPINRequest) error {
+	if req.UserID == "" {
+		return errors.New("user_id is required")
+	}
+	if err := s.ValidatePINFormat(req.PIN); err != nil {
+		return err
+	}
+	stored, err := s.repo.Get(ctx, req.UserID)
+	if err != nil {
+		return errors.New("pin not set")
+	}
+	candidate := hashPIN(req.PIN, stored.Salt)
+	if subtle.ConstantTimeCompare([]byte(candidate), []byte(stored.Hash)) != 1 {
+		return errors.New("invalid pin")
+	}
+	return nil
+}


### PR DESCRIPTION
### 📄 Summary
- ➕ Adds biometric authentication flow via **PIN setup and login**.  
- 💾 Stores **salted + hashed PINs** in Redis and verifies during login.  

---

### 🌐 Endpoints
- `POST /api/v1/auth/setup-pin`  
- `POST /api/v1/auth/login-pin`  

---

### 📦 Request Payloads
**Setup PIN:**  
- `user_id` *(string, required)*  
- `pin` *(string, required, 4–6 digits numeric)*  

**Login PIN:**  
- `user_id` *(string, required)*  
- `pin` *(string, required, 4–6 digits numeric)*  

---

### 📤 Responses
- **Setup PIN:**  
  - `200 OK` → success  
  - `400` → validation errors  
  - `500` → internal errors  

- **Login PIN:**  
  - `200 OK` → success  
  - `400` → validation errors  
  - `401` → invalid_pin  
  - `404` → pin not set  
  - `500` → internal errors  

---

### 🛠️ Implementation Details
- **Models:** `pin.go`  
- **Repository:** `pin_repository.go`  
- **Service:** `pin_service.go`  
- **Handler:** `pin_handler.go`  
- **Routing:** `main.go`  

---

### 🔒 Security
- 🧂 PINs salted + hashed with **SHA-256**.  
- ⏱️ Uses constant-time comparison to prevent timing attacks.  
- 🔮 Future: consider **argon2id/bcrypt** for stronger hashing.  

---

### 🧪 Testing
1. Ensure Redis is running:  
   ```bash
   docker compose up -d
