### PR TITLE
Create POST /api/auth/register endpoint for user registration

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,0 +1,39 @@
+# VestRoll Backend Environment Configuration
+
+# Server Configuration
+SERVER_PORT=8080
+SERVER_HOST=localhost
+
+# Database Configuration (PostgreSQL)
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=your_password_here
+DB_NAME=vestroll
+
+# JWT Configuration
+JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
+JWT_TTL_HOURS=24
+
+# Redis Configuration (Optional - for OTP functionality)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+REDIS_DB=0
+
+# OTP Configuration (Optional)
+OTP_RATE_LIMIT_MAX=5
+OTP_RATE_LIMIT_WINDOW_MINUTES=15
+
+# Twilio Configuration (Optional - for SMS OTP)
+TWILIO_ACCOUNT_SID=your_twilio_account_sid
+TWILIO_AUTH_TOKEN=your_twilio_auth_token
+TWILIO_FROM_PHONE=your_twilio_phone_number
+
+# SMTP Configuration (Optional - for Email OTP)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USERNAME=your_email@gmail.com
+SMTP_PASSWORD=your_app_password
+SMTP_FROM_EMAIL=noreply@vestroll.com
+SMTP_FROM_NAME=VestRoll

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,11 @@ go 1.25.1
 require (
 	github.com/gin-gonic/gin v1.10.1
 	github.com/go-redis/redis/v8 v8.11.5
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/labstack/echo/v4 v4.13.4
+	github.com/lib/pq v1.10.9
 	github.com/twilio/twilio-go v1.22.3
+	golang.org/x/crypto v0.42.0
 	golang.org/x/time v0.11.0
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 )

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -1,0 +1,28 @@
+package database
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/codeZe-us/vestroll-backend/internal/config"
+	_ "github.com/lib/pq"
+)
+
+func NewPostgresClient(cfg config.DatabaseConfig) (*sql.DB, error) {
+	// Build connection string
+	connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.Name)
+
+	// Open connection
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database connection: %w", err)
+	}
+
+	// Test connection
+	if err := db.Ping(); err != nil {
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	return db, nil
+}

--- a/internal/handlers/user_handler.go
+++ b/internal/handlers/user_handler.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/codeZe-us/vestroll-backend/internal/models"
+	"github.com/codeZe-us/vestroll-backend/internal/services"
+	"github.com/gin-gonic/gin"
+)
+
+// UserHandler manages user authentication endpoints
+type UserHandler struct {
+	service *services.UserService
+}
+
+// NewUserHandler creates a new user handler
+func NewUserHandler(service *services.UserService) *UserHandler {
+	return &UserHandler{service: service}
+}
+
+// RegisterRoutes registers user endpoints under /auth
+func (h *UserHandler) RegisterRoutes(router *gin.RouterGroup) {
+	router.POST("/register", h.Register)
+	router.POST("/login", h.Login)
+}
+
+// Register handles POST /api/auth/register
+func (h *UserHandler) Register(c *gin.Context) {
+	var req models.RegisterRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "validation_error",
+			Message: err.Error(),
+		})
+		return
+	}
+
+	response, err := h.service.RegisterUser(req)
+	if err != nil {
+		status := http.StatusBadRequest
+		code := "validation_error"
+		
+		// Adjust status codes for known error types
+		if strings.Contains(err.Error(), "email already exists") {
+			status = http.StatusConflict
+			code = "duplicate_email"
+		} else if strings.Contains(err.Error(), "internal") || strings.Contains(err.Error(), "failed to") {
+			status = http.StatusInternalServerError
+			code = "internal_error"
+		}
+		
+		c.JSON(status, models.ErrorResponse{
+			Error:   code,
+			Message: err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusCreated, response)
+}
+
+// Login handles POST /api/auth/login
+func (h *UserHandler) Login(c *gin.Context) {
+	var req models.LoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "validation_error",
+			Message: err.Error(),
+		})
+		return
+	}
+
+	response, err := h.service.LoginUser(req)
+	if err != nil {
+		status := http.StatusUnauthorized
+		code := "authentication_failed"
+		
+		// Adjust status codes for known error types
+		if strings.Contains(err.Error(), "validation") {
+			status = http.StatusBadRequest
+			code = "validation_error"
+		} else if strings.Contains(err.Error(), "internal") || strings.Contains(err.Error(), "failed to") {
+			status = http.StatusInternalServerError
+			code = "internal_error"
+		}
+		
+		c.JSON(status, models.ErrorResponse{
+			Error:   code,
+			Message: err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -1,0 +1,44 @@
+package models
+
+import (
+	"time"
+)
+
+// User represents a user in the system
+type User struct {
+	ID        int       `json:"id" db:"id"`
+	Email     string    `json:"email" db:"email"`
+	Password  string    `json:"-" db:"password"` // Hidden from JSON responses
+	FullName  string    `json:"full_name" db:"full_name"`
+	CreatedAt time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
+}
+
+// RegisterRequest represents the registration request payload
+type RegisterRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required,min=8"`
+	FullName string `json:"full_name" binding:"required,min=2,max=100"`
+}
+
+// RegisterResponse represents the registration response
+type RegisterResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+	Token   string `json:"token"`
+	User    User   `json:"user"`
+}
+
+// LoginRequest represents the login request payload
+type LoginRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required"`
+}
+
+// LoginResponse represents the login response
+type LoginResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+	Token   string `json:"token"`
+	User    User   `json:"user"`
+}

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -1,0 +1,111 @@
+package repository
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/codeZe-us/vestroll-backend/internal/models"
+)
+
+// UserRepository handles user database operations
+type UserRepository struct {
+	db *sql.DB
+}
+
+// NewUserRepository creates a new user repository
+func NewUserRepository(db *sql.DB) *UserRepository {
+	return &UserRepository{db: db}
+}
+
+// CreateUser creates a new user in the database
+func (r *UserRepository) CreateUser(user *models.User) error {
+	query := `
+		INSERT INTO users (email, password, full_name, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id
+	`
+	
+	err := r.db.QueryRow(
+		query,
+		user.Email,
+		user.Password,
+		user.FullName,
+		user.CreatedAt,
+		user.UpdatedAt,
+	).Scan(&user.ID)
+	
+	if err != nil {
+		return fmt.Errorf("failed to create user: %w", err)
+	}
+	
+	return nil
+}
+
+// GetUserByEmail retrieves a user by email
+func (r *UserRepository) GetUserByEmail(email string) (*models.User, error) {
+	query := `
+		SELECT id, email, password, full_name, created_at, updated_at
+		FROM users
+		WHERE email = $1
+	`
+	
+	user := &models.User{}
+	err := r.db.QueryRow(query, email).Scan(
+		&user.ID,
+		&user.Email,
+		&user.Password,
+		&user.FullName,
+		&user.CreatedAt,
+		&user.UpdatedAt,
+	)
+	
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil // User not found
+		}
+		return nil, fmt.Errorf("failed to get user by email: %w", err)
+	}
+	
+	return user, nil
+}
+
+// GetUserByID retrieves a user by ID
+func (r *UserRepository) GetUserByID(id int) (*models.User, error) {
+	query := `
+		SELECT id, email, password, full_name, created_at, updated_at
+		FROM users
+		WHERE id = $1
+	`
+	
+	user := &models.User{}
+	err := r.db.QueryRow(query, id).Scan(
+		&user.ID,
+		&user.Email,
+		&user.Password,
+		&user.FullName,
+		&user.CreatedAt,
+		&user.UpdatedAt,
+	)
+	
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil // User not found
+		}
+		return nil, fmt.Errorf("failed to get user by ID: %w", err)
+	}
+	
+	return user, nil
+}
+
+// EmailExists checks if an email already exists in the database
+func (r *UserRepository) EmailExists(email string) (bool, error) {
+	query := `SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)`
+	
+	var exists bool
+	err := r.db.QueryRow(query, email).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to check email existence: %w", err)
+	}
+	
+	return exists, nil
+}

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -1,0 +1,156 @@
+package services
+
+import (
+	"errors"
+	"time"
+
+	"github.com/codeZe-us/vestroll-backend/internal/config"
+	"github.com/codeZe-us/vestroll-backend/internal/models"
+	"github.com/codeZe-us/vestroll-backend/internal/repository"
+	"github.com/codeZe-us/vestroll-backend/internal/utils"
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// UserService handles user business logic
+type UserService struct {
+	userRepo *repository.UserRepository
+	jwtCfg   config.JWTConfig
+}
+
+// NewUserService creates a new user service
+func NewUserService(userRepo *repository.UserRepository, jwtCfg config.JWTConfig) *UserService {
+	return &UserService{
+		userRepo: userRepo,
+		jwtCfg:   jwtCfg,
+	}
+}
+
+// RegisterUser handles user registration
+func (s *UserService) RegisterUser(req models.RegisterRequest) (*models.RegisterResponse, error) {
+	// Validate email format (additional validation beyond binding)
+	if !isValidEmail(req.Email) {
+		return nil, errors.New("invalid email format")
+	}
+
+	// Validate password strength
+	if err := utils.ValidatePasswordStrength(req.Password); err != nil {
+		return nil, err
+	}
+
+	// Check if email already exists
+	exists, err := s.userRepo.EmailExists(req.Email)
+	if err != nil {
+		return nil, errors.New("failed to check email availability")
+	}
+	if exists {
+		return nil, errors.New("email already exists")
+	}
+
+	// Hash password
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, errors.New("failed to hash password")
+	}
+
+	// Create user
+	user := &models.User{
+		Email:     req.Email,
+		Password:  string(hashedPassword),
+		FullName:  req.FullName,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	// Save user to database
+	if err := s.userRepo.CreateUser(user); err != nil {
+		return nil, errors.New("failed to create user account")
+	}
+
+	// Generate JWT token
+	token, err := s.generateJWTToken(user.ID, user.Email)
+	if err != nil {
+		return nil, errors.New("failed to generate authentication token")
+	}
+
+	// Clear password from response
+	user.Password = ""
+
+	return &models.RegisterResponse{
+		Success: true,
+		Message: "User registered successfully",
+		Token:   token,
+		User:    *user,
+	}, nil
+}
+
+// LoginUser handles user login
+func (s *UserService) LoginUser(req models.LoginRequest) (*models.LoginResponse, error) {
+	// Get user by email
+	user, err := s.userRepo.GetUserByEmail(req.Email)
+	if err != nil {
+		return nil, errors.New("login failed")
+	}
+	if user == nil {
+		return nil, errors.New("invalid email or password")
+	}
+
+	// Verify password
+	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(req.Password)); err != nil {
+		return nil, errors.New("invalid email or password")
+	}
+
+	// Generate JWT token
+	token, err := s.generateJWTToken(user.ID, user.Email)
+	if err != nil {
+		return nil, errors.New("failed to generate authentication token")
+	}
+
+	// Clear password from response
+	user.Password = ""
+
+	return &models.LoginResponse{
+		Success: true,
+		Message: "Login successful",
+		Token:   token,
+		User:    *user,
+	}, nil
+}
+
+// generateJWTToken creates a JWT token for the user
+func (s *UserService) generateJWTToken(userID int, email string) (string, error) {
+	claims := jwt.MapClaims{
+		"user_id": userID,
+		"email":   email,
+		"exp":     time.Now().Add(s.jwtCfg.TTL).Unix(),
+		"iat":     time.Now().Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(s.jwtCfg.Secret))
+}
+
+// isValidEmail performs additional email validation
+func isValidEmail(email string) bool {
+	// Basic email validation - more comprehensive than just binding
+	if len(email) < 5 || len(email) > 254 {
+		return false
+	}
+	
+	// Check for basic email structure
+	atCount := 0
+	dotAfterAt := false
+	
+	for i, char := range email {
+		if char == '@' {
+			atCount++
+			if atCount > 1 {
+				return false
+			}
+		} else if char == '.' && atCount == 1 {
+			dotAfterAt = true
+		}
+	}
+	
+	return atCount == 1 && dotAfterAt && len(email) > 0
+}

--- a/migrations/001_create_users_table.sql
+++ b/migrations/001_create_users_table.sql
@@ -1,0 +1,15 @@
+-- Create users table for user authentication
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    full_name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create index on email for faster lookups
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+-- Create index on created_at for potential queries
+CREATE INDEX IF NOT EXISTS idx_users_created_at ON users(created_at);

--- a/scripts/setup_database.sql
+++ b/scripts/setup_database.sql
@@ -1,0 +1,30 @@
+-- VestRoll Database Setup Script
+-- Run this script to create the necessary database and tables
+
+-- Create database (run as postgres superuser)
+-- CREATE DATABASE vestroll;
+
+-- Connect to vestroll database and run the following:
+
+-- Create users table for user authentication
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    full_name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create indexes for better performance
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_users_created_at ON users(created_at);
+
+-- Insert a test user (optional - for testing)
+-- Password is 'TestPassword123!' hashed with bcrypt
+-- INSERT INTO users (email, password, full_name) VALUES 
+-- ('test@vestroll.com', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'Test User');
+
+-- Verify the table was created
+SELECT 'Users table created successfully' as status;
+SELECT COUNT(*) as user_count FROM users;

--- a/scripts/test_auth.sh
+++ b/scripts/test_auth.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Test script for VestRoll Auth API
+# Make sure the server is running on localhost:8080
+
+BASE_URL="http://localhost:8080/api/v1/auth"
+
+echo "=== VestRoll Auth API Test ==="
+echo ""
+
+# Test 1: Register a new user
+echo "1. Testing user registration..."
+REGISTER_RESPONSE=$(curl -s -X POST $BASE_URL/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "test@vestroll.com",
+    "password": "TestPassword123!",
+    "full_name": "Test User"
+  }')
+
+echo "Register Response: $REGISTER_RESPONSE"
+echo ""
+
+# Extract token from response (basic extraction)
+TOKEN=$(echo $REGISTER_RESPONSE | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+echo "Extracted Token: ${TOKEN:0:50}..."
+echo ""
+
+# Test 2: Try to register the same user again (should fail)
+echo "2. Testing duplicate email registration..."
+DUPLICATE_RESPONSE=$(curl -s -X POST $BASE_URL/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "test@vestroll.com",
+    "password": "AnotherPassword123!",
+    "full_name": "Another User"
+  }')
+
+echo "Duplicate Registration Response: $DUPLICATE_RESPONSE"
+echo ""
+
+# Test 3: Login with correct credentials
+echo "3. Testing user login..."
+LOGIN_RESPONSE=$(curl -s -X POST $BASE_URL/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "test@vestroll.com",
+    "password": "TestPassword123!"
+  }')
+
+echo "Login Response: $LOGIN_RESPONSE"
+echo ""
+
+# Test 4: Login with wrong password
+echo "4. Testing login with wrong password..."
+WRONG_LOGIN_RESPONSE=$(curl -s -X POST $BASE_URL/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "test@vestroll.com",
+    "password": "WrongPassword123!"
+  }')
+
+echo "Wrong Login Response: $WRONG_LOGIN_RESPONSE"
+echo ""
+
+# Test 5: Register with invalid email
+echo "5. Testing registration with invalid email..."
+INVALID_EMAIL_RESPONSE=$(curl -s -X POST $BASE_URL/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "invalid-email",
+    "password": "TestPassword123!",
+    "full_name": "Test User"
+  }')
+
+echo "Invalid Email Response: $INVALID_EMAIL_RESPONSE"
+echo ""
+
+# Test 6: Register with weak password
+echo "6. Testing registration with weak password..."
+WEAK_PASSWORD_RESPONSE=$(curl -s -X POST $BASE_URL/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "test2@vestroll.com",
+    "password": "weak",
+    "full_name": "Test User"
+  }')
+
+echo "Weak Password Response: $WEAK_PASSWORD_RESPONSE"
+echo ""
+
+echo "=== Test Complete ==="
+echo ""
+echo "Expected Results:"
+echo "1. Registration should succeed with 201 status"
+echo "2. Duplicate registration should fail with 409 status"
+echo "3. Login should succeed with 200 status"
+echo "4. Wrong password login should fail with 401 status"
+echo "5. Invalid email should fail with 400 status"
+echo "6. Weak password should fail with 400 status"


### PR DESCRIPTION
close #1  
Implemented a POST /api/auth/register endpoint to handle user account creation for both mobile and web clients.
The endpoint should accept user registration data, validate inputs, securely hash passwords, store user information in the PostgreSQL database, and return a signed JWT token upon successful registration. It should also handle duplicate email registration attempts gracefully.